### PR TITLE
Fix narrow inspector resizing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ node_modules/
 .vite/
 coverage/
 .pytest_cache/
+.playwright-cli/
 .DS_Store
 *.tsbuildinfo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [TBD]
 ### Added
 - Added `agentlens --version` to print the published CLI package version.
+
+### Fixed
+- Improved narrow browser resizing so Sessions and Trace Inspector remain usable while the Timeline TOC is hidden.
+- Wrapped long Trace Inspector event text inside event cards instead of overflowing at narrow widths.
 
 ## [0.3.0] - 2026-03-25
 ### Added
@@ -71,7 +75,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Documentation
 - Updated Gemini-related docs as part of the initial release train.
 
-[Unreleased]: https://github.com/RobertTLange/agentlens/compare/v0.3.0...HEAD
+[TBD]: https://github.com/RobertTLange/agentlens/compare/v0.3.0...HEAD
 [0.3.0]: https://github.com/RobertTLange/agentlens/compare/v0.2.3...v0.3.0
 [0.2.3]: https://github.com/RobertTLange/agentlens/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/RobertTLange/agentlens/compare/v0.2.1...v0.2.2

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3098,6 +3098,14 @@ body {
   }
 }
 
+@media (max-width: 560px) {
+  .detail-summary-cards:not(.detail-summary-cards-four-up),
+  .detail-summary-cards,
+  .detail-summary-cards.detail-summary-cards-four-up {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 520px) {
   .grid {
     grid-template-columns: 1fr;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2774,6 +2774,7 @@ body {
   overflow-y: auto;
   overflow-x: hidden;
   min-height: 0;
+  min-width: 0;
   padding: 10px;
   display: grid;
   gap: 10px;
@@ -2785,6 +2786,10 @@ body {
   padding: 9px;
   background: #fff;
   position: relative;
+  min-width: 0;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  word-break: break-word;
   content-visibility: auto;
   contain-intrinsic-size: 168px;
   transition:
@@ -2831,11 +2836,18 @@ body {
   color: var(--muted);
   font-size: 0.72rem;
   padding-right: 88px;
+  min-width: 0;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .event-card h3 {
   margin: 6px 0;
   font-size: 0.95rem;
+  min-width: 0;
+  max-width: 100%;
+  line-height: 1.25;
   overflow-wrap: anywhere;
   word-break: break-word;
 }
@@ -2863,11 +2875,14 @@ body {
   padding: 8px;
   font-size: 0.78rem;
   font-family: "IBM Plex Mono", monospace;
+  min-width: 0;
   max-width: 100%;
 }
 
 .subtle {
   color: var(--muted);
+  min-width: 0;
+  max-width: 100%;
   overflow-wrap: anywhere;
   word-break: break-word;
 }
@@ -2886,6 +2901,15 @@ body {
   font-size: 0.65rem;
   color: #1e3a8a;
   background: #eff6ff;
+}
+
+.event-card .kind,
+.event-card .event-agent-badge {
+  min-width: 0;
+  max-width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .kind {
@@ -2986,9 +3010,18 @@ body {
   }
 
   .grid {
-    grid-template-columns: 1fr;
-    grid-template-rows: repeat(3, minmax(0, 1fr));
+    grid-template-columns: minmax(260px, 0.9fr) minmax(0, 1.4fr);
+    grid-template-rows: minmax(0, 1fr);
     height: 100%;
+  }
+
+  .toc-panel {
+    display: none;
+  }
+
+  .detail-summary-cards,
+  .detail-summary-cards.detail-summary-cards-four-up {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .event-kind-filter-menu {
@@ -3062,5 +3095,12 @@ body {
 
   .activity-time {
     font-size: 0.52rem;
+  }
+}
+
+@media (max-width: 520px) {
+  .grid {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(0, 0.62fr) minmax(0, 1.38fr);
   }
 }

--- a/apps/web/src/styles.test.ts
+++ b/apps/web/src/styles.test.ts
@@ -2,6 +2,7 @@
 
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { Window } from "happy-dom";
 import { describe, expect, it } from "vitest";
 
 const stylesPath = fileURLToPath(new URL("./styles.css", import.meta.url));
@@ -24,6 +25,44 @@ function mediaBlock(maxWidthPx: number): string {
   }
 
   throw new Error(`Unclosed media block for max-width ${maxWidthPx}px`);
+}
+
+function renderResponsiveInspector(widthPx: number) {
+  const window = new Window({ width: widthPx, height: 720 });
+  window.document.head.innerHTML = `<style>${styles}</style>`;
+  window.document.body.innerHTML = `
+    <div class="grid">
+      <section class="panel list-panel"></section>
+      <section class="panel toc-panel"></section>
+      <section class="panel detail-panel">
+        <section class="detail-summary-cards">
+          <article class="detail-summary-card"></article>
+          <article class="detail-summary-card"></article>
+          <article class="detail-summary-card"></article>
+        </section>
+        <div class="events-scroll">
+          <article class="event-card">
+            <div class="event-top mono">
+              <span class="kind kind-tool_use">tool_use</span>
+            </div>
+            <h3>verylongeventpreviewwithoutnaturalbreakpoints</h3>
+          </article>
+        </div>
+      </section>
+    </div>
+  `;
+
+  return window.document;
+}
+
+function computedStyle(document: ReturnType<typeof renderResponsiveInspector>) {
+  return (selector: string) => {
+    const element = document.querySelector(selector);
+    if (!element) throw new Error(`Missing rendered element for selector ${selector}`);
+    const view = document.defaultView;
+    if (!view) throw new Error(`Missing defaultView for selector ${selector}`);
+    return view.getComputedStyle(element);
+  };
 }
 
 describe("responsive inspector layout styles", () => {
@@ -49,5 +88,21 @@ describe("responsive inspector layout styles", () => {
     expect(styles).toMatch(/\.event-top\s*{[^}]*min-width:\s*0;/s);
     expect(styles).toMatch(/\.subtle\s*{[^}]*min-width:\s*0;/s);
     expect(styles).toMatch(/\.event-card \.kind,\s*\.event-card \.event-agent-badge\s*{[^}]*white-space:\s*normal;/s);
+  });
+
+  it("renders the responsive inspector breakpoints with computed viewport styles", () => {
+    const narrowDesktop = renderResponsiveInspector(960);
+    const narrowDesktopStyle = computedStyle(narrowDesktop);
+    expect(narrowDesktopStyle(".toc-panel").display).toBe("none");
+    expect(narrowDesktopStyle(".grid").gridTemplateColumns).toBe("minmax(260px, 0.9fr) minmax(0, 1.4fr)");
+
+    const narrowInspector = renderResponsiveInspector(530);
+    const narrowInspectorStyle = computedStyle(narrowInspector);
+    expect(narrowInspectorStyle(".detail-summary-cards").gridTemplateColumns).toBe("1fr");
+    expect(narrowInspectorStyle(".event-card h3").overflowWrap).toBe("anywhere");
+
+    const phone = renderResponsiveInspector(520);
+    const phoneStyle = computedStyle(phone);
+    expect(phoneStyle(".grid").gridTemplateColumns).toBe("1fr");
   });
 });

--- a/apps/web/src/styles.test.ts
+++ b/apps/web/src/styles.test.ts
@@ -1,0 +1,53 @@
+/* @vitest-environment node */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const stylesPath = fileURLToPath(new URL("./styles.css", import.meta.url));
+const styles = readFileSync(stylesPath, "utf8");
+
+function mediaBlock(maxWidthPx: number): string {
+  const marker = `@media (max-width: ${maxWidthPx}px)`;
+  const start = styles.indexOf(marker);
+  expect(start).toBeGreaterThanOrEqual(0);
+
+  const blockStart = styles.indexOf("{", start);
+  expect(blockStart).toBeGreaterThanOrEqual(0);
+
+  let depth = 0;
+  for (let index = blockStart; index < styles.length; index += 1) {
+    const char = styles[index];
+    if (char === "{") depth += 1;
+    if (char === "}") depth -= 1;
+    if (depth === 0) return styles.slice(blockStart + 1, index);
+  }
+
+  throw new Error(`Unclosed media block for max-width ${maxWidthPx}px`);
+}
+
+describe("responsive inspector layout styles", () => {
+  it("hides the timeline toc and keeps a two-pane inspector layout at narrow desktop widths", () => {
+    const block = mediaBlock(960);
+
+    expect(block).toMatch(/\.toc-panel\s*{[^}]*display:\s*none;/s);
+    expect(block).toMatch(/\.grid\s*{[^}]*grid-template-columns:\s*minmax\(260px,\s*0\.9fr\)\s*minmax\(0,\s*1\.4fr\);/s);
+    expect(block).toMatch(/\.grid\s*{[^}]*grid-template-rows:\s*minmax\(0,\s*1fr\);/s);
+  });
+
+  it("stacks the primary inspector panes only at phone widths", () => {
+    const block = mediaBlock(520);
+
+    expect(block).toMatch(/\.grid\s*{[^}]*grid-template-columns:\s*1fr;/s);
+    expect(block).toMatch(/\.grid\s*{[^}]*grid-template-rows:\s*minmax\(0,\s*0\.62fr\)\s*minmax\(0,\s*1\.38fr\);/s);
+  });
+
+  it("allows trace inspector event text to shrink and wrap inside narrow cards", () => {
+    expect(styles).toMatch(/\.event-card\s*{[^}]*min-width:\s*0;/s);
+    expect(styles).toMatch(/\.event-card\s*{[^}]*overflow-wrap:\s*anywhere;/s);
+    expect(styles).toMatch(/\.event-card h3\s*{[^}]*min-width:\s*0;/s);
+    expect(styles).toMatch(/\.event-top\s*{[^}]*min-width:\s*0;/s);
+    expect(styles).toMatch(/\.subtle\s*{[^}]*min-width:\s*0;/s);
+    expect(styles).toMatch(/\.event-card \.kind,\s*\.event-card \.event-agent-badge\s*{[^}]*white-space:\s*normal;/s);
+  });
+});


### PR DESCRIPTION
## Summary
- keep Sessions and Trace Inspector usable at narrow widths by hiding the Timeline TOC
- make Trace Inspector event cards and badges wrap long text within their cards
- document the TBD release notes and ignore Playwright CLI scratch artifacts

## Verification
- npm -w apps/web test
- npm run typecheck
- npm test
- npm run build