### PR TITLE
Improve live rendering performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - Added `agentlens --version` to print the published CLI package version.
 
+### Changed
+- Paced live session, Timeline TOC, timeline strip, and Trace Inspector rendering so large live bursts reveal over animation-frame chunks while counts and status stay current.
+- Trace Inspector now requests compact event payloads for collapsed cards and lazy-loads full raw JSON only when an event is expanded.
+
 ### Fixed
 - Improved narrow browser resizing so Sessions and Trace Inspector remain usable while the Timeline TOC is hidden.
 - Wrapped long Trace Inspector event text inside event cards instead of overflowing at narrow widths.
+- Reduced browser main-thread and memory pressure for large trace sessions that previously triggered Chrome tab slowdown warnings.
+
+### Performance
+- Lowered large trace detail payloads by omitting full raw provider JSON from the initial inspector render path.
 
 ## [0.3.0] - 2026-03-25
 ### Added

--- a/apps/server/src/app.test.ts
+++ b/apps/server/src/app.test.ts
@@ -2123,7 +2123,7 @@ describe("server api", () => {
     expect(traceById.statusCode).toBe(200);
     const detail = traceById.json() as {
       summary: { sessionId: string; path: string };
-      events: Array<{ toolCallId?: string; toolArgsText?: string; toolResultText?: string }>;
+      events: Array<{ eventId?: string; toolCallId?: string; toolArgsText?: string; toolResultText?: string }>;
       toc?: Array<{ label: string; eventKind: string }>;
     };
     expect(detail.summary.sessionId).toBe(fixture.sessionId);
@@ -2134,6 +2134,28 @@ describe("server api", () => {
     expect(detail.toc?.length).toBeGreaterThan(0);
     expect(detail.toc?.[0]?.label).toBe("Tool: run_command");
     expect(detail.toc?.[0]?.eventKind).toBe("tool_use");
+
+    const compactTraceById = await server.inject({ method: "GET", url: `/api/trace/${traceId}?payload=compact` });
+    expect(compactTraceById.statusCode).toBe(200);
+    const compactDetail = compactTraceById.json() as {
+      events: Array<{ raw: Record<string, unknown>; searchText: string; textBlocks: unknown[] }>;
+      eventPayload: string;
+    };
+    expect(compactDetail.eventPayload).toBe("compact");
+    expect(compactDetail.events[0]?.raw).toEqual({ type: "response_item" });
+    expect(compactDetail.events[0]?.searchText).toBe("");
+    expect(compactDetail.events[0]?.textBlocks).toEqual([]);
+
+    const eventId = detail.events[0]?.eventId;
+    if (!eventId) throw new Error("missing event id");
+    const traceEvent = await server.inject({
+      method: "GET",
+      url: `/api/trace/${traceId}/event/${encodeURIComponent(eventId)}`,
+    });
+    expect(traceEvent.statusCode).toBe(200);
+    expect((traceEvent.json() as { event: { raw: { payload?: { arguments?: string } } } }).event.raw.payload?.arguments).toContain(
+      "echo hi",
+    );
 
     const traceBySession = await server.inject({ method: "GET", url: `/api/trace/${fixture.sessionId}` });
     expect(traceBySession.statusCode).toBe(200);

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -19,6 +19,7 @@ import type {
   NormalizedEvent,
   OverviewUpdatedLiveEnvelope,
   SessionDetail,
+  TraceEventPayloadMode,
   TraceSummary,
   TraceRemovedLiveEnvelope,
   TraceUpsertLiveEnvelope,
@@ -355,14 +356,31 @@ function resolveTraceFilePathFromToken(encodedPath: string): string {
   return normalizedPath;
 }
 
-function parseTracePageOptions(query: { limit?: string; before?: string; include_meta?: string }): {
+function parseTracePayloadMode(value: string | undefined): TraceEventPayloadMode | undefined {
+  if (value === "compact") return "compact";
+  if (value === "full") return "full";
+  return undefined;
+}
+
+function parseTraceIncludeMeta(value: string | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  return value === "1" || value === "true";
+}
+
+function parseTracePageOptions(query: { limit?: string; before?: string; include_meta?: string; payload?: string }): {
   limit?: number;
   before?: string;
   includeMeta?: boolean;
+  eventPayload?: TraceEventPayloadMode;
 } {
-  const pageOptions: { limit?: number; before?: string; includeMeta?: boolean } = {};
-  if (query.include_meta !== undefined) {
-    pageOptions.includeMeta = query.include_meta === "1" || query.include_meta === "true";
+  const pageOptions: { limit?: number; before?: string; includeMeta?: boolean; eventPayload?: TraceEventPayloadMode } = {};
+  const includeMeta = parseTraceIncludeMeta(query.include_meta);
+  if (includeMeta !== undefined) {
+    pageOptions.includeMeta = includeMeta;
+  }
+  const eventPayload = parseTracePayloadMode(query.payload);
+  if (eventPayload !== undefined) {
+    pageOptions.eventPayload = eventPayload;
   }
   if (query.limit) {
     pageOptions.limit = Number(query.limit);
@@ -400,7 +418,7 @@ function buildAdHocTraceConfig(baseConfig: AppConfig, traceFilePath: string): Ap
 async function loadAdHocTracePage(
   traceIndex: TraceIndex,
   traceFilePath: string,
-  pageOptions: { limit?: number; before?: string; includeMeta?: boolean },
+  pageOptions: { limit?: number; before?: string; includeMeta?: boolean; eventPayload?: TraceEventPayloadMode },
 ) {
   const adHocConfig = buildAdHocTraceConfig(traceIndex.getConfig(), traceFilePath);
   const adHocIndex = new TraceIndex(adHocConfig);
@@ -410,6 +428,22 @@ async function loadAdHocTracePage(
     throw new Error("trace file not parseable");
   }
   return adHocIndex.getTracePage(matchingSummary.id, pageOptions);
+}
+
+async function loadAdHocTraceEvent(
+  traceIndex: TraceIndex,
+  traceFilePath: string,
+  eventId: string,
+  options: { includeMeta?: boolean },
+) {
+  const adHocConfig = buildAdHocTraceConfig(traceIndex.getConfig(), traceFilePath);
+  const adHocIndex = new TraceIndex(adHocConfig);
+  await adHocIndex.refresh();
+  const matchingSummary = adHocIndex.getSummaries().find((summary) => path.resolve(summary.path) === traceFilePath);
+  if (!matchingSummary) {
+    throw new Error("trace file not parseable");
+  }
+  return adHocIndex.getTraceEvent(matchingSummary.id, eventId, options);
 }
 
 function listRecentTraceSummaries(
@@ -2344,7 +2378,7 @@ export async function createServer(options: CreateServerOptions): Promise<Fastif
 
   server.get("/api/trace/:id", async (request, reply) => {
     const params = request.params as { id: string };
-    const query = request.query as { limit?: string; before?: string; include_meta?: string };
+    const query = request.query as { limit?: string; before?: string; include_meta?: string; payload?: string };
 
     try {
       const resolvedId = traceIndex.resolveId(params.id);
@@ -2357,8 +2391,23 @@ export async function createServer(options: CreateServerOptions): Promise<Fastif
     }
   });
 
+  server.get("/api/trace/:id/event/:eventId", async (request, reply) => {
+    const params = request.params as { id: string; eventId: string };
+    const query = request.query as { include_meta?: string };
+    const includeMeta = parseTraceIncludeMeta(query.include_meta);
+
+    try {
+      const resolvedId = traceIndex.resolveId(params.id);
+      const event = traceIndex.getTraceEvent(resolvedId, params.eventId, includeMeta === undefined ? {} : { includeMeta });
+      return { event };
+    } catch (error) {
+      reply.code(404);
+      return { error: error instanceof Error ? error.message : String(error) };
+    }
+  });
+
   server.get("/api/tracefile", async (request, reply) => {
-    const query = request.query as { path?: string; limit?: string; before?: string; include_meta?: string };
+    const query = request.query as { path?: string; limit?: string; before?: string; include_meta?: string; payload?: string };
 
     try {
       const encodedPath = typeof query.path === "string" ? query.path : "";
@@ -2375,6 +2424,46 @@ export async function createServer(options: CreateServerOptions): Promise<Fastif
       ) {
         reply.code(400);
       } else if (message === "trace file not found" || message === "trace file path is not a file") {
+        reply.code(404);
+      } else {
+        reply.code(500);
+      }
+      return { error: message };
+    }
+  });
+
+  server.get("/api/tracefile/event", async (request, reply) => {
+    const query = request.query as { path?: string; event_id?: string; include_meta?: string };
+
+    try {
+      const encodedPath = typeof query.path === "string" ? query.path : "";
+      const eventId = typeof query.event_id === "string" ? query.event_id : "";
+      if (!eventId) {
+        reply.code(400);
+        return { error: "event_id is required" };
+      }
+      const traceFilePath = resolveTraceFilePathFromToken(encodedPath);
+      const includeMeta = parseTraceIncludeMeta(query.include_meta);
+      const event = await loadAdHocTraceEvent(
+        traceIndex,
+        traceFilePath,
+        eventId,
+        includeMeta === undefined ? {} : { includeMeta },
+      );
+      return { event };
+    } catch (error) {
+      const message = asErrorMessage(error);
+      if (
+        message === "invalid trace file token" ||
+        message === "invalid trace file path" ||
+        message === "trace file path must be absolute"
+      ) {
+        reply.code(400);
+      } else if (
+        message === "trace file not found" ||
+        message === "trace file path is not a file" ||
+        message.startsWith("unknown trace event:")
+      ) {
         reply.code(404);
       } else {
         reply.code(500);

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -747,6 +747,34 @@ function flushRafQueue(): void {
   });
 }
 
+function visibleLiveItemCounts(): { toc: number; strip: number; cards: number } {
+  return {
+    toc: document.querySelectorAll(".toc-row").length,
+    strip: document.querySelectorAll(".timeline-segment").length,
+    cards: document.querySelectorAll(".event-card").length,
+  };
+}
+
+function visibleTraceRowIds(): string[] {
+  return Array.from(document.querySelectorAll<HTMLElement>(".trace-row")).map((row) => row.dataset.traceId ?? "");
+}
+
+function stubReducedMotion(matches: boolean): void {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn((query: string) => ({
+      matches: query === "(prefers-reduced-motion: reduce)" ? matches : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })) as unknown as typeof window.matchMedia,
+  );
+}
+
 function installTimelineStripScrollTo(scroller: HTMLDivElement) {
   const scrollToSpy = vi.fn((options?: ScrollToOptions | number, y?: number) => {
     if (typeof options === "number") {
@@ -2530,7 +2558,9 @@ describe("App sessions list live motion", () => {
       expect(nextMeta?.textContent).toContain("session-trace-c");
       expect(nextMeta?.textContent).toContain("7 events");
     });
-    expect(document.querySelector(".detail-head-title-block.pulse")).not.toBeNull();
+    flushRafQueue();
+    flushRafQueue();
+    await waitFor(() => expect(document.querySelector(".detail-head-title-block.pulse")).not.toBeNull());
   });
 
   it("shows running and waiting indicators from backend activity status", async () => {
@@ -2610,7 +2640,10 @@ describe("App sessions list live motion", () => {
       source.emit("trace_updated", { summary: resumedTrace });
     });
 
-    await waitFor(() => expect(getTraceRow("trace-c").querySelector(".trace-status-chip")?.textContent).toBe("Running"));
+    await waitFor(() => {
+      flushRafQueue();
+      expect(getTraceRow("trace-c").querySelector(".trace-status-chip")?.textContent).toBe("Running");
+    });
   });
 
   it("shows stop failure error in the session row when terminate endpoint rejects", async () => {
@@ -3351,9 +3384,10 @@ describe("App sessions list live motion", () => {
     });
     flushRafQueue();
 
-    await waitFor(() =>
-      expect(getTraceRow("trace-b").querySelector(".trace-row-inner.pulse")).not.toBeNull(),
-    );
+    await waitFor(() => {
+      flushRafQueue();
+      expect(getTraceRow("trace-b").querySelector(".trace-row-inner.pulse")).not.toBeNull();
+    });
     expect(getTraceRow("trace-a").querySelector(".trace-row-inner.pulse")).toBeNull();
 
     const addedD = makeTrace("trace-d", 5_000);
@@ -3363,7 +3397,48 @@ describe("App sessions list live motion", () => {
     });
     flushRafQueue();
 
-    await waitFor(() => expect(getTraceRow("trace-d").querySelector(".trace-row-inner.pulse")).not.toBeNull());
+    await waitFor(() => {
+      flushRafQueue();
+      expect(getTraceRow("trace-d").querySelector(".trace-row-inner.pulse")).not.toBeNull();
+    });
+  });
+
+  it("keeps live counters immediate while session row reorder and pulse work is scheduled once per batch", async () => {
+    render(<App />);
+    await waitFor(() => expect(document.querySelectorAll(".trace-row").length).toBe(3));
+    expect(visibleTraceRowIds()).toEqual(["trace-c", "trace-b", "trace-a"]);
+
+    const source = MockEventSource.instances[0];
+    expect(source).toBeTruthy();
+    if (!source) return;
+
+    const staleB = {
+      ...makeTrace("trace-b", 4_000, "waiting_input"),
+      eventCount: 4,
+    };
+    const finalB = {
+      ...makeTrace("trace-b", 6_000, "running"),
+      eventCount: 8,
+    };
+
+    act(() => {
+      source.emit("batch", {
+        events: [
+          { id: "b-stale", type: "trace_updated", version: 1, payload: { summary: staleB } },
+          { id: "b-final", type: "trace_updated", version: 2, payload: { summary: finalB } },
+        ],
+      });
+    });
+
+    expect(document.querySelector(".session-head-counter.status-running")?.textContent).toBe("running 1");
+    expect(visibleTraceRowIds()).toEqual(["trace-c", "trace-b", "trace-a"]);
+    expect(getTraceRow("trace-b").querySelector(".trace-row-inner.pulse")).toBeNull();
+
+    flushRafQueue();
+    await waitFor(() => expect(visibleTraceRowIds()).toEqual(["trace-b", "trace-c", "trace-a"]));
+    flushRafQueue();
+    await waitFor(() => expect(getTraceRow("trace-b").querySelector(".trace-row-inner.pulse")).not.toBeNull());
+    expect(getTraceRow("trace-b").querySelector(".trace-status-chip")?.textContent).toBe("Running");
   });
 
   it("animates only cards whose list position changed", async () => {
@@ -3409,6 +3484,7 @@ describe("App sessions list live motion", () => {
     act(() => {
       source.emit("trace_updated", { summary: updatedB });
     });
+    flushRafQueue();
 
     await waitFor(() => expect(getTraceRow("trace-b").style.transform).toBe("translateY(100px)"));
     expect(getTraceRow("trace-c").style.transform).toBe("translateY(-100px)");
@@ -3767,6 +3843,136 @@ describe("App sessions list live motion", () => {
       const resumeButton = document.querySelector(".inspector-resume-follow-button");
       expect(eventCardCount >= 1 || resumeButton !== null).toBe(true);
     });
+  });
+
+  it("keeps counters current while large streamed event bursts reveal in frame chunks", async () => {
+    const selectedTrace = tracesById["trace-c"];
+    if (!selectedTrace) throw new Error("missing trace-c test fixture");
+
+    const firstEvent = makeEvent("event-paced-first", { signature: "first payload" });
+    tracePagesById["trace-c"] = makeTracePageWithEvents(selectedTrace, [firstEvent]);
+
+    render(<App />);
+    await waitFor(() => expect(document.querySelectorAll(".event-card").length).toBe(1));
+    flushRafQueue();
+
+    const appendedEvents: NormalizedEvent[] = Array.from({ length: 24 }, (_, idx) => ({
+      ...makeEvent(`event-paced-${idx}`, { signature: `paced payload ${idx}` }),
+      index: 5 + idx,
+      offset: 5 + idx,
+      timestampMs: 2_000 + idx,
+      preview: `paced payload ${idx}`,
+      textBlocks: [`paced payload ${idx}`],
+      tocLabel: `paced payload ${idx}`,
+      searchText: `paced payload ${idx}`,
+    }));
+    const updatedSummary = {
+      ...selectedTrace,
+      eventCount: selectedTrace.eventCount + appendedEvents.length,
+      mtimeMs: selectedTrace.mtimeMs + 2_000,
+      lastEventTs: appendedEvents.at(-1)?.timestampMs ?? selectedTrace.lastEventTs,
+    };
+    tracePagesById["trace-c"] = makeTracePageWithEvents(updatedSummary, [firstEvent, ...appendedEvents]);
+
+    const source = MockEventSource.instances[0];
+    expect(source).toBeTruthy();
+    if (!source) return;
+
+    act(() => {
+      source.emit("batch", {
+        events: [
+          { id: "summary", type: "trace_updated", version: 1, payload: { summary: updatedSummary } },
+          {
+            id: "append",
+            type: "events_appended",
+            version: 2,
+            payload: { id: "trace-c", appended: appendedEvents.length, latestEvents: appendedEvents },
+          },
+          {
+            id: "overview",
+            type: "overview_updated",
+            version: 3,
+            payload: { overview: { ...overview, eventCount: overview.eventCount + appendedEvents.length } },
+          },
+        ],
+      });
+    });
+
+    await waitFor(() => expect(document.querySelector(".detail-head-meta")?.textContent).toContain("26 events"));
+    expect(document.querySelector(".hero-metrics")?.textContent).toContain("events 30");
+    expect(visibleLiveItemCounts()).toEqual({ toc: 1, strip: 1, cards: 1 });
+    expect(getInspectorResumeFollowButton().textContent).toContain("24 new");
+
+    flushRafQueue();
+    await waitFor(() => {
+      const counts = visibleLiveItemCounts();
+      expect(counts.toc).toBeGreaterThan(1);
+      expect(counts.toc).toBeLessThan(25);
+      expect(counts.strip).toBe(counts.toc);
+      expect(counts.cards).toBe(counts.toc);
+    });
+
+    const firstFrameCount = visibleLiveItemCounts().cards;
+    flushRafQueue();
+    await waitFor(() => {
+      const counts = visibleLiveItemCounts();
+      expect(counts.cards).toBeGreaterThan(firstFrameCount);
+      expect(counts.cards).toBeLessThan(25);
+      expect(counts.strip).toBe(counts.cards);
+      expect(counts.toc).toBe(counts.cards);
+    });
+
+    await waitFor(() => {
+      flushRafQueue();
+      expect(visibleLiveItemCounts()).toEqual({ toc: 25, strip: 25, cards: 25 });
+    });
+    expect(document.querySelector(".inspector-resume-follow-button")).toBeNull();
+    expect(countTraceDetailRequests("trace-c")).toBe(1);
+  });
+
+  it("paces reduced-motion appends without enter animation classes", async () => {
+    stubReducedMotion(true);
+    const selectedTrace = tracesById["trace-c"];
+    if (!selectedTrace) throw new Error("missing trace-c test fixture");
+
+    const firstEvent = makeEvent("event-reduced-first", { signature: "first payload" });
+    const appendedEvents: NormalizedEvent[] = Array.from({ length: 12 }, (_, idx) => ({
+      ...makeEvent(`event-reduced-${idx}`, { signature: `reduced payload ${idx}` }),
+      index: 5 + idx,
+      offset: 5 + idx,
+      timestampMs: 2_000 + idx,
+      preview: `reduced payload ${idx}`,
+      textBlocks: [`reduced payload ${idx}`],
+      tocLabel: `reduced payload ${idx}`,
+      searchText: `reduced payload ${idx}`,
+    }));
+    tracePagesById["trace-c"] = makeTracePageWithEvents(selectedTrace, [firstEvent]);
+
+    render(<App />);
+    await waitFor(() => expect(document.querySelectorAll(".event-card").length).toBe(1));
+
+    const source = MockEventSource.instances[0];
+    expect(source).toBeTruthy();
+    if (!source) return;
+
+    act(() => {
+      source.emit("events_appended", {
+        id: "trace-c",
+        appended: appendedEvents.length,
+        latestEvents: appendedEvents,
+      });
+    });
+
+    expect(visibleLiveItemCounts()).toEqual({ toc: 1, strip: 1, cards: 1 });
+    flushRafQueue();
+    await waitFor(() => {
+      const counts = visibleLiveItemCounts();
+      expect(counts.cards).toBeGreaterThan(1);
+      expect(counts.cards).toBeLessThan(13);
+    });
+    expect(document.querySelector(".toc-row-enter")).toBeNull();
+    expect(document.querySelector(".timeline-segment-enter")).toBeNull();
+    expect(document.querySelector(".event-card-enter")).toBeNull();
   });
 
   it("applies burst batches without refetching selected trace detail when latest events are included", async () => {

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -573,14 +573,27 @@ function makeEvent(eventId: string, raw: Record<string, unknown>): NormalizedEve
 }
 
 function traceIdFromTraceUrl(url: string): string {
-  const match = url.match(/\/api\/trace\/([^?]+)/);
+  const match = url.match(/\/api\/trace\/([^/?]+)/);
   return decodeURIComponent(match?.[1] ?? "");
+}
+
+function traceEventPartsFromUrl(url: string): { traceId: string; eventId: string } {
+  const match = url.match(/\/api\/trace\/([^/]+)\/event\/([^?]+)/);
+  return {
+    traceId: decodeURIComponent(match?.[1] ?? ""),
+    eventId: decodeURIComponent(match?.[2] ?? ""),
+  };
 }
 
 function encodedPathFromTraceFileUrl(url: string): string {
   const parsed = new URL(url, "http://localhost");
   if (!parsed.pathname.includes("/api/tracefile")) return "";
   return parsed.searchParams.get("path") ?? "";
+}
+
+function eventIdFromTraceFileEventUrl(url: string): string {
+  const parsed = new URL(url, "http://localhost");
+  return parsed.searchParams.get("event_id") ?? "";
 }
 
 function traceIdFromStopUrl(url: string): string {
@@ -612,6 +625,7 @@ function getTraceDetailRequests(traceId: string): string[] {
     if (!url.includes(detailUrlFragment)) return false;
     if (url.includes("/stop")) return false;
     if (url.includes("/open")) return false;
+    if (url.includes("/event/")) return false;
     return true;
   });
 }
@@ -964,6 +978,17 @@ beforeEach(() => {
         const body = custom?.body ?? { ok: true, status: "sent_tmux", message: "sent input to tmux pane" };
         return new Response(JSON.stringify(body), { status });
       }
+      if (url.includes("/api/tracefile/event")) {
+        const encodedPath = encodedPathFromTraceFileUrl(url);
+        const eventId = eventIdFromTraceFileEventUrl(url);
+        const tracePage =
+          Object.values(tracePagesById).find((candidate) => encodeBase64UrlUtf8(candidate.summary.path) === encodedPath) ??
+          Object.values(tracePagesById)[0];
+        const event = tracePage?.events.find((candidate) => candidate.eventId === eventId);
+        return event
+          ? new Response(JSON.stringify({ event }), { status: 200 })
+          : new Response(JSON.stringify({ error: "unknown trace event" }), { status: 404 });
+      }
       if (url.includes("/api/tracefile")) {
         const encodedPath = encodedPathFromTraceFileUrl(url);
         if (missingAdHocEncodedPaths.has(encodedPath)) {
@@ -976,6 +1001,14 @@ beforeEach(() => {
           return new Response("{}", { status: 404 });
         }
         return new Response(JSON.stringify(tracePage), { status: 200 });
+      }
+      if (url.includes("/api/trace/") && url.includes("/event/")) {
+        const { traceId, eventId } = traceEventPartsFromUrl(url);
+        const tracePage = tracePagesById[traceId] ?? Object.values(tracePagesById)[0];
+        const event = tracePage?.events.find((candidate) => candidate.eventId === eventId);
+        return event
+          ? new Response(JSON.stringify({ event }), { status: 200 })
+          : new Response(JSON.stringify({ error: "unknown trace event" }), { status: 404 });
       }
       if (url.includes("/api/trace/")) {
         const traceId = traceIdFromTraceUrl(url);
@@ -1013,6 +1046,17 @@ describe("App sessions list live motion", () => {
       "https://github.com/RobertTLange/agentlens",
     );
     expect(document.querySelector("footer")).toBeNull();
+  });
+
+  it("requests compact trace pages for the inspector", async () => {
+    render(<App />);
+    await waitFor(() => expect(getTraceDetailRequests("trace-c").length).toBeGreaterThan(0));
+
+    const detailRequest = getTraceDetailRequests("trace-c")[0];
+    if (!detailRequest) throw new Error("missing trace detail request");
+    const url = new URL(detailRequest, "http://localhost");
+    expect(url.searchParams.get("payload")).toBe("compact");
+    expect(url.searchParams.get("limit")).toBe("1200");
   });
 
   it("shows warming state in the inspector while history hydration is still partial", async () => {
@@ -3529,6 +3573,7 @@ describe("App sessions list live motion", () => {
     const rawBlock = document.querySelector(".event-raw-json");
     expect(rawBlock).toBeTruthy();
     expect(rawBlock?.textContent).toContain(longToken);
+    expect(requestedUrls.some((url) => url.includes("/api/trace/trace-c/event/event-expand-1"))).toBe(true);
   });
 
   it("keeps expanded event JSON open when selected trace refreshes live", async () => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -44,8 +44,7 @@ const RECENT_TRACE_LIMIT = 500;
 const TRACE_PAGE_CACHE_ENTRY_LIMIT = RECENT_TRACE_LIMIT * 2;
 const PRIMARY_RECENT_SESSION_COUNT = 20;
 const OLDER_TRACE_PAGE_SIZE = 40;
-const EVENT_APPEND_REVEAL_CHUNK_SIZE = 8;
-const EVENT_APPEND_REVEAL_INTERVAL_MS = 16;
+const LIVE_EVENT_REVEAL_FRAME_BUDGET = 8;
 const EVENT_KIND_OPTIONS: EventKind[] = ["system", "assistant", "user", "tool_use", "tool_result", "reasoning", "compaction", "meta"];
 const EVENT_KIND_LABEL_BY_KIND: Record<EventKind, string> = {
   system: "system",
@@ -330,6 +329,12 @@ function clearAnimationTimers(timerById: Map<string, number>): void {
   timerById.clear();
 }
 
+function reducedMotionPreferred(): boolean {
+  return typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
 function readTimelineStripViewport(scroller: HTMLElement): { hasOverflow: boolean; atLatest: boolean } {
   const hasOverflow = scroller.scrollWidth > scroller.clientWidth + 1;
   if (!hasOverflow) return { hasOverflow: false, atLatest: true };
@@ -382,6 +387,7 @@ export function App(): JSX.Element {
   const [overview, setOverview] = useState<OverviewStats | null>(null);
   const [startup, setStartup] = useState<IndexStartupStatus | null>(null);
   const [traces, setTraces] = useState<TraceSummary[]>([]);
+  const [sessionRenderTraces, setSessionRenderTraces] = useState<TraceSummary[]>([]);
   const [activeAdHocEncodedPath, setActiveAdHocEncodedPath] = useState(() =>
     typeof window === "undefined" ? "" : adHocEncodedPathFromLocationPathname(window.location.pathname),
   );
@@ -427,6 +433,7 @@ export function App(): JSX.Element {
   const [inspectorPendingAppendCount, setInspectorPendingAppendCount] = useState(0);
   const selectedIdRef = useRef("");
   const tracesRef = useRef<TraceSummary[]>([]);
+  const sessionRenderTracesRef = useRef<TraceSummary[]>([]);
   const pageRef = useRef<TracePage | null>(null);
   const pendingLatestEventsByTraceIdRef = useRef<Map<string, TracePage["events"]>>(new Map());
   const eventTypeFilterRef = useRef<HTMLDivElement | null>(null);
@@ -447,8 +454,11 @@ export function App(): JSX.Element {
   const previousAnimatedEventFilterKeyRef = useRef("");
   const previousPageEventIdsRef = useRef<Set<string>>(new Set());
   const queuedEventIdsRef = useRef<string[]>([]);
+  const queuedEventIdSetRef = useRef<Set<string>>(new Set());
   const queuedEventFlushRafRef = useRef<number | null>(null);
-  const queuedEventFlushTimerRef = useRef<number | null>(null);
+  const pendingSessionRenderTracesRef = useRef<TraceSummary[] | null>(null);
+  const pendingSessionPulseTraceIdsRef = useRef<Set<string>>(new Set());
+  const sessionRenderRafRef = useRef<number | null>(null);
   const enterAnimationTimerByTraceIdRef = useRef<Map<string, number>>(new Map());
   const enterAnimationTimerByEventIdRef = useRef<Map<string, number>>(new Map());
   const flashStatusFadeTimerRef = useRef<number | null>(null);
@@ -489,13 +499,22 @@ export function App(): JSX.Element {
       return search.includes(q);
     });
   }, [traces, query]);
+  const filteredSessionRenderTraces = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const base = sortTraces(sessionRenderTraces);
+    if (!q) return base;
+    return base.filter((trace) => {
+      const search = `${trace.path}\n${trace.agent}\n${trace.sessionId}\n${trace.id}`.toLowerCase();
+      return search.includes(q);
+    });
+  }, [query, sessionRenderTraces]);
   const primaryTraces = useMemo(
-    () => filteredTraces.slice(0, PRIMARY_RECENT_SESSION_COUNT),
-    [filteredTraces],
+    () => filteredSessionRenderTraces.slice(0, PRIMARY_RECENT_SESSION_COUNT),
+    [filteredSessionRenderTraces],
   );
   const olderTraces = useMemo(
-    () => filteredTraces.slice(PRIMARY_RECENT_SESSION_COUNT),
-    [filteredTraces],
+    () => filteredSessionRenderTraces.slice(PRIMARY_RECENT_SESSION_COUNT),
+    [filteredSessionRenderTraces],
   );
   const visibleOlderTraces = useMemo(
     () => olderTraces.slice(0, olderTraceRenderLimit),
@@ -739,11 +758,8 @@ export function App(): JSX.Element {
       window.cancelAnimationFrame(queuedEventFlushRafRef.current);
       queuedEventFlushRafRef.current = null;
     }
-    if (queuedEventFlushTimerRef.current !== null) {
-      window.clearTimeout(queuedEventFlushTimerRef.current);
-      queuedEventFlushTimerRef.current = null;
-    }
     queuedEventIdsRef.current = [];
+    queuedEventIdSetRef.current.clear();
     setInspectorPendingAppendCount((value) => (value === 0 ? value : 0));
   }, []);
 
@@ -770,12 +786,11 @@ export function App(): JSX.Element {
       window.cancelAnimationFrame(queuedEventFlushRafRef.current);
       queuedEventFlushRafRef.current = null;
     }
-    if (queuedEventFlushTimerRef.current !== null) {
-      window.clearTimeout(queuedEventFlushTimerRef.current);
-      queuedEventFlushTimerRef.current = null;
-    }
     if (queuedEventIdsRef.current.length === 0) return;
-    const queued = queuedEventIdsRef.current.splice(0, EVENT_APPEND_REVEAL_CHUNK_SIZE);
+    const queued = queuedEventIdsRef.current.splice(0, LIVE_EVENT_REVEAL_FRAME_BUDGET);
+    for (const eventId of queued) {
+      queuedEventIdSetRef.current.delete(eventId);
+    }
     const remainingCount = queuedEventIdsRef.current.length;
     setInspectorPendingAppendCount((value) => (value === remainingCount ? value : remainingCount));
     setVisibleEventIds((prev) => {
@@ -783,35 +798,38 @@ export function App(): JSX.Element {
       for (const eventId of queued) next.add(eventId);
       return next;
     });
-    setEnteringEventIds((prev) => {
-      const next = new Set(prev);
-      for (const eventId of queued) next.add(eventId);
-      return next;
-    });
-    for (const eventId of queued) {
-      scheduleEventEnterAnimationCleanup(eventId);
+    if (!reducedMotionPreferred()) {
+      setEnteringEventIds((prev) => {
+        const next = new Set(prev);
+        for (const eventId of queued) next.add(eventId);
+        return next;
+      });
+      for (const eventId of queued) {
+        scheduleEventEnterAnimationCleanup(eventId);
+      }
     }
     if (queuedEventIdsRef.current.length > 0) {
-      queuedEventFlushTimerRef.current = window.setTimeout(() => {
-        queuedEventFlushTimerRef.current = null;
-        queuedEventFlushRafRef.current = window.requestAnimationFrame(() => {
-          queuedEventFlushRafRef.current = null;
-          flushQueuedEvents();
-        });
-      }, EVENT_APPEND_REVEAL_INTERVAL_MS);
+      queuedEventFlushRafRef.current = window.requestAnimationFrame(() => {
+        queuedEventFlushRafRef.current = null;
+        flushQueuedEvents();
+      });
     }
   }, [scheduleEventEnterAnimationCleanup]);
 
   const enqueueEventsForAppendReveal = useCallback(
     (eventIds: string[]): void => {
       if (eventIds.length === 0) return;
-      const queuedEventIdSet = new Set(queuedEventIdsRef.current);
+      let queuedChanged = false;
       for (const eventId of eventIds) {
-        if (queuedEventIdSet.has(eventId)) continue;
-        queuedEventIdSet.add(eventId);
+        if (queuedEventIdSetRef.current.has(eventId)) continue;
+        queuedEventIdSetRef.current.add(eventId);
         queuedEventIdsRef.current.push(eventId);
+        queuedChanged = true;
       }
-      if (queuedEventFlushRafRef.current !== null || queuedEventFlushTimerRef.current !== null) return;
+      if (!queuedChanged) return;
+      const queuedCount = queuedEventIdsRef.current.length;
+      setInspectorPendingAppendCount((value) => (value === queuedCount ? value : queuedCount));
+      if (queuedEventFlushRafRef.current !== null) return;
       queuedEventFlushRafRef.current = window.requestAnimationFrame(() => {
         queuedEventFlushRafRef.current = null;
         flushQueuedEvents();
@@ -822,11 +840,10 @@ export function App(): JSX.Element {
 
   const queueEventsWithoutReveal = useCallback((eventIds: string[]): void => {
     if (eventIds.length === 0) return;
-    const queuedEventIdSet = new Set(queuedEventIdsRef.current);
     let queuedChanged = false;
     for (const eventId of eventIds) {
-      if (queuedEventIdSet.has(eventId)) continue;
-      queuedEventIdSet.add(eventId);
+      if (queuedEventIdSetRef.current.has(eventId)) continue;
+      queuedEventIdSetRef.current.add(eventId);
       queuedEventIdsRef.current.push(eventId);
       queuedChanged = true;
     }
@@ -874,7 +891,6 @@ export function App(): JSX.Element {
     scrollEventsToLatest("smooth");
     eventsPinnedToLatestRef.current = true;
     setEventsPinnedToLatest((value) => (value ? value : true));
-    setInspectorPendingAppendCount(0);
   }, [flushQueuedEvents, scrollEventsToLatest, timelineStripEvents]);
 
   const handleTimelineStripScroll = useCallback((): void => {
@@ -912,6 +928,10 @@ export function App(): JSX.Element {
   useEffect(() => {
     tracesRef.current = traces;
   }, [traces]);
+
+  useEffect(() => {
+    sessionRenderTracesRef.current = sessionRenderTraces;
+  }, [sessionRenderTraces]);
 
   useEffect(() => {
     pageRef.current = page;
@@ -968,6 +988,10 @@ export function App(): JSX.Element {
   useEffect(
     () => () => {
       clearEventAppendQueue();
+      if (sessionRenderRafRef.current !== null) {
+        window.cancelAnimationFrame(sessionRenderRafRef.current);
+        sessionRenderRafRef.current = null;
+      }
       clearFlashStatusTimers();
       clearAnimationTimers(enterAnimationTimerByTraceIdRef.current);
       clearAnimationTimers(enterAnimationTimerByEventIdRef.current);
@@ -999,6 +1023,35 @@ export function App(): JSX.Element {
     };
   }, [applyTimelineStripViewport]);
 
+  const scheduleSessionRender = useCallback((nextTraces: TraceSummary[], pulseTraceIds: Set<string> = new Set()): void => {
+    pendingSessionRenderTracesRef.current = nextTraces;
+    for (const traceId of pulseTraceIds) {
+      if (traceId) pendingSessionPulseTraceIdsRef.current.add(traceId);
+    }
+    if (sessionRenderRafRef.current !== null) return;
+
+    sessionRenderRafRef.current = window.requestAnimationFrame(() => {
+      sessionRenderRafRef.current = null;
+      const pendingTraces = pendingSessionRenderTracesRef.current;
+      pendingSessionRenderTracesRef.current = null;
+      if (pendingTraces) {
+        sessionRenderTracesRef.current = pendingTraces;
+        setSessionRenderTraces(pendingTraces);
+      }
+
+      const pulseTraceIdsToApply = Array.from(pendingSessionPulseTraceIdsRef.current);
+      pendingSessionPulseTraceIdsRef.current.clear();
+      if (pulseTraceIdsToApply.length === 0) return;
+      setPulseSeqByTraceId((prev) => {
+        const next = { ...prev };
+        for (const traceId of pulseTraceIdsToApply) {
+          next[traceId] = (next[traceId] ?? 0) + 1;
+        }
+        return next;
+      });
+    });
+  }, []);
+
   useEffect(() => {
     const traceRenderKey = `${query.trim().toLowerCase()}|${showOlderTraces ? "open" : "closed"}|${olderTraceRenderLimit}`;
     const filterChanged = previousTraceFilterRef.current !== traceRenderKey;
@@ -1016,6 +1069,11 @@ export function App(): JSX.Element {
     const appendedTraceIds = renderedTraceIds.filter((traceId) => !previousVisibleTraceIdsRef.current.has(traceId));
     previousVisibleTraceIdsRef.current = currentTraceIds;
     if (appendedTraceIds.length === 0) return;
+    if (reducedMotionPreferred()) {
+      setEnteringTraceIds(new Set());
+      clearAnimationTimers(enterAnimationTimerByTraceIdRef.current);
+      return;
+    }
 
     setEnteringTraceIds((prev) => {
       const next = new Set(prev);
@@ -1043,14 +1101,6 @@ export function App(): JSX.Element {
   }, [olderTraceRenderLimit, query, renderedTraceIds, showOlderTraces]);
 
   useEffect(() => {
-    const bumpPulse = (traceId: string): void => {
-      if (!traceId) return;
-      setPulseSeqByTraceId((prev) => ({
-        ...prev,
-        [traceId]: (prev[traceId] ?? 0) + 1,
-      }));
-    };
-
     const loadBoot = async (): Promise<void> => {
       try {
         const [overviewResp, tracesResp] = await Promise.all([
@@ -1059,9 +1109,11 @@ export function App(): JSX.Element {
         ]);
         const sorted = limitRecentTraces(tracesResp.traces.map(applyManualStopOverride));
         tracesRef.current = sorted;
+        sessionRenderTracesRef.current = sorted;
         setOverview(overviewResp.overview);
         setStartup(overviewResp.startup);
         setTraces(sorted);
+        setSessionRenderTraces(sorted);
         setSelectedId((prev) => {
           if (prev) return prev;
           if (activeAdHocEncodedPath) return `${AD_HOC_TRACE_ID_PREFIX}${activeAdHocEncodedPath}`;
@@ -1078,6 +1130,7 @@ export function App(): JSX.Element {
       delete manualStopAtByTraceIdRef.current[id];
       removeTracePageCacheEntries(tracePageCacheRef.current, id);
       pendingLatestEventsByTraceIdRef.current.delete(id);
+      pendingSessionPulseTraceIdsRef.current.delete(id);
       removeTraceRow(id);
       setEnteringTraceIds((prev) => {
         if (!prev.has(id)) return prev;
@@ -1204,6 +1257,7 @@ export function App(): JSX.Element {
 
       if (tracesChanged) {
         setTraces(nextTraces);
+        scheduleSessionRender(nextTraces, pulseTraceIds);
         setSelectedId((prev) => {
           if (prev && removedIds.has(prev)) return "";
           if (prev) return prev;
@@ -1266,10 +1320,6 @@ export function App(): JSX.Element {
       }
       setStatus(`Live: ${nextTraces.length} traces`);
       setLastLiveUpdateMs(Date.now());
-
-      for (const traceId of pulseTraceIds) {
-        bumpPulse(traceId);
-      }
     };
 
     const enqueueLiveDeltas = (deltas: LiveDeltaEnvelope[]): void => {
@@ -1288,8 +1338,10 @@ export function App(): JSX.Element {
         };
         const nextTraces = limitRecentTraces((data.payload?.traces ?? []).map(applyManualStopOverride));
         tracesRef.current = nextTraces;
+        sessionRenderTracesRef.current = nextTraces;
         if (nextTraces.length > 0) {
           setTraces(nextTraces);
+          setSessionRenderTraces(nextTraces);
           setSelectedId((prev) => prev || nextTraces[0]?.id || "");
         }
         if (data.payload?.overview) setOverview(data.payload.overview);
@@ -1340,7 +1392,7 @@ export function App(): JSX.Element {
     return () => {
       source.close();
     };
-  }, [activeAdHocEncodedPath, applyManualStopOverride, removeTraceRow]);
+  }, [activeAdHocEncodedPath, applyManualStopOverride, removeTraceRow, scheduleSessionRender]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -1650,6 +1702,7 @@ export function App(): JSX.Element {
 
     const nextQueuedEventIds = queuedEventIdsRef.current.filter((eventId) => currentEventIdSet.has(eventId));
     queuedEventIdsRef.current = nextQueuedEventIds;
+    queuedEventIdSetRef.current = new Set(nextQueuedEventIds);
     const queuedCount = nextQueuedEventIds.length;
     setInspectorPendingAppendCount((value) => (value === queuedCount ? value : queuedCount));
     if (appendedEventIds.length > 0) {
@@ -1812,7 +1865,7 @@ export function App(): JSX.Element {
       }
       const stoppedAtMs = Date.now();
       manualStopAtByTraceIdRef.current[traceId] = stoppedAtMs;
-      setTraces((prev) => {
+      const markTraceStopped = (prev: TraceSummary[]): TraceSummary[] => {
         const index = prev.findIndex((trace) => trace.id === traceId);
         if (index < 0) return prev;
         const current = prev[index];
@@ -1824,7 +1877,9 @@ export function App(): JSX.Element {
           activityReason: "manually_stopped",
         };
         return sortTraces(next);
-      });
+      };
+      setTraces(markTraceStopped);
+      setSessionRenderTraces(markTraceStopped);
       const signalLabel = payload.signal?.trim() ? payload.signal : "signal";
       flashHeaderStatus(`Stop requested (${signalLabel}) for ${traceId}`);
       setLastLiveUpdateMs(stoppedAtMs);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,6 +5,7 @@ import type {
   IndexStartupStatus,
   LiveBatchEnvelope,
   LiveDeltaEnvelope,
+  NormalizedEvent,
   OverviewStats,
   TracePage,
   TraceSummary,
@@ -38,6 +39,8 @@ const CLOCK_TICK_MS = 10_000;
 const TIMELINE_EVENT_INITIAL_RENDER_LIMIT = 240;
 const TIMELINE_EVENT_RENDER_STEP = 240;
 const TIMELINE_EVENT_RENDER_PREFETCH_PX = 320;
+const TRACE_DETAIL_EVENT_LIMIT = 1200;
+const TRACE_DETAIL_PAYLOAD = "compact";
 const TOOL_CALL_TYPES_PER_SUMMARY_ROW = 3;
 const TOOL_CALL_SUMMARY_ROW_LIMIT = 2;
 const RECENT_TRACE_LIMIT = 500;
@@ -61,6 +64,10 @@ const DEFAULT_VISIBLE_EVENT_KINDS: EventKind[] = EVENT_KIND_OPTIONS.filter((kind
 interface OverviewResponse {
   overview: OverviewStats;
   startup: IndexStartupStatus;
+}
+
+interface TraceEventResponse {
+  event: NormalizedEvent;
 }
 
 interface StopTraceResponse {
@@ -409,6 +416,9 @@ export function App(): JSX.Element {
   const [tocQuery, setTocQuery] = useState("");
   const [selectedEventId, setSelectedEventId] = useState("");
   const [expandedEventIds, setExpandedEventIds] = useState<Set<string>>(new Set());
+  const [expandedEventById, setExpandedEventById] = useState<Record<string, NormalizedEvent>>({});
+  const [loadingExpandedEventIds, setLoadingExpandedEventIds] = useState<Set<string>>(new Set());
+  const [expandedEventErrorById, setExpandedEventErrorById] = useState<Record<string, string>>({});
   const [expandedPathTraceIds, setExpandedPathTraceIds] = useState<Set<string>>(new Set());
   const [autoFollow, setAutoFollow] = useState(true);
   const [timelineSortDirection, setTimelineSortDirection] = useState<TimelineSortDirection>("latest-first");
@@ -1451,6 +1461,31 @@ export function App(): JSX.Element {
         }
         return next;
       });
+      setExpandedEventById((prev) => {
+        if (isTraceChanged) return {};
+        const next: Record<string, NormalizedEvent> = {};
+        for (const [eventId, event] of Object.entries(prev)) {
+          if (eventIds.has(eventId)) next[eventId] = event;
+        }
+        return next;
+      });
+      setExpandedEventErrorById((prev) => {
+        if (isTraceChanged) return {};
+        const next: Record<string, string> = {};
+        for (const [eventId, message] of Object.entries(prev)) {
+          if (eventIds.has(eventId)) next[eventId] = message;
+        }
+        return next;
+      });
+      setLoadingExpandedEventIds((prev) => {
+        if (prev.size === 0) return prev;
+        if (isTraceChanged) return new Set();
+        const next = new Set<string>();
+        for (const eventId of prev) {
+          if (eventIds.has(eventId)) next.add(eventId);
+        }
+        return next;
+      });
       setSelectedEventId((prev) => {
         if (prev && detail.events.some((event) => event.eventId === prev)) {
           return prev;
@@ -1483,8 +1518,8 @@ export function App(): JSX.Element {
       try {
         const detail = await fetchJson<TracePage>(
           isAdHocSelection
-            ? `${API}/api/tracefile?path=${encodeURIComponent(selectedAdHocEncodedPath)}&limit=1200&include_meta=${includeMeta ? "1" : "0"}`
-            : `${API}/api/trace/${encodeURIComponent(selectedId)}?limit=1200&include_meta=${includeMeta ? "1" : "0"}`,
+            ? `${API}/api/tracefile?path=${encodeURIComponent(selectedAdHocEncodedPath)}&limit=${TRACE_DETAIL_EVENT_LIMIT}&include_meta=${includeMeta ? "1" : "0"}&payload=${TRACE_DETAIL_PAYLOAD}`
+            : `${API}/api/trace/${encodeURIComponent(selectedId)}?limit=${TRACE_DETAIL_EVENT_LIMIT}&include_meta=${includeMeta ? "1" : "0"}&payload=${TRACE_DETAIL_PAYLOAD}`,
           { signal: abortController.signal },
         );
         if (abortController.signal.aborted) return;
@@ -1757,13 +1792,57 @@ export function App(): JSX.Element {
     }, 0);
   };
 
+  const loadExpandedEvent = useCallback(
+    async (eventId: string): Promise<void> => {
+      if (!selectedId || expandedEventById[eventId] || loadingExpandedEventIds.has(eventId)) return;
+      setLoadingExpandedEventIds((prev) => {
+        if (prev.has(eventId)) return prev;
+        const next = new Set(prev);
+        next.add(eventId);
+        return next;
+      });
+      setExpandedEventErrorById((prev) => {
+        if (!(eventId in prev)) return prev;
+        const next = { ...prev };
+        delete next[eventId];
+        return next;
+      });
+
+      try {
+        const detail = await fetchJson<TraceEventResponse>(
+          isAdHocTraceSelection(selectedId)
+            ? `${API}/api/tracefile/event?path=${encodeURIComponent(selectedId.slice(AD_HOC_TRACE_ID_PREFIX.length))}&event_id=${encodeURIComponent(eventId)}&include_meta=${includeMeta ? "1" : "0"}`
+            : `${API}/api/trace/${encodeURIComponent(selectedId)}/event/${encodeURIComponent(eventId)}?include_meta=${includeMeta ? "1" : "0"}`,
+        );
+        setExpandedEventById((prev) => ({ ...prev, [eventId]: detail.event }));
+      } catch (error) {
+        setExpandedEventErrorById((prev) => ({
+          ...prev,
+          [eventId]: error instanceof Error ? error.message : String(error),
+        }));
+      } finally {
+        setLoadingExpandedEventIds((prev) => {
+          if (!prev.has(eventId)) return prev;
+          const next = new Set(prev);
+          next.delete(eventId);
+          return next;
+        });
+      }
+    },
+    [expandedEventById, includeMeta, loadingExpandedEventIds, selectedId],
+  );
+
   const toggleExpanded = (eventId: string): void => {
+    const willExpand = !expandedEventIds.has(eventId);
     setExpandedEventIds((prev) => {
       const next = new Set(prev);
       if (next.has(eventId)) next.delete(eventId);
       else next.add(eventId);
       return next;
     });
+    if (willExpand) {
+      void loadExpandedEvent(eventId);
+    }
   };
 
   const toggleTracePathExpanded = (traceId: string): void => {
@@ -2354,6 +2433,9 @@ export function App(): JSX.Element {
                 >
                   {renderedTimelineEvents.map((event) => {
                     const agentBadges = buildAgentBadges(event);
+                    const expandedEvent = expandedEventById[event.eventId] ?? event;
+                    const expandedEventLoading = loadingExpandedEventIds.has(event.eventId);
+                    const expandedEventError = expandedEventErrorById[event.eventId] ?? "";
                     return (
                       <article
                         key={event.eventId}
@@ -2386,7 +2468,14 @@ export function App(): JSX.Element {
                           </div>
                         )}
                         {expandedEventIds.has(event.eventId) && (
-                          <pre className="event-raw-json">{JSON.stringify(event.raw, null, 2)}</pre>
+                          expandedEventLoading && !expandedEventById[event.eventId] ? (
+                            <div className="event-raw-status mono">Loading raw event...</div>
+                          ) : (
+                            <>
+                              {expandedEventError && <div className="event-raw-status mono">{expandedEventError}</div>}
+                              <pre className="event-raw-json">{JSON.stringify(expandedEvent.raw, null, 2)}</pre>
+                            </>
+                          )
                         )}
                       </article>
                     );

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2879,6 +2879,12 @@ body {
   max-width: 100%;
 }
 
+.event-raw-status {
+  margin: 7px 0 0;
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
 .subtle {
   color: var(--muted);
   min-width: 0;

--- a/docs/api.md
+++ b/docs/api.md
@@ -10,13 +10,15 @@ Base URL (default): `http://127.0.0.1:8787`
 | `GET /api/overview` | Aggregate counters and distributions |
 | `GET /api/perf` | Index refresh timings, watcher stats, retention stats |
 | `GET /api/traces?agent=<name>&limit=<n>` | Trace summaries |
-| `GET /api/trace/:id` | Trace detail by trace id or session id (`limit`, `before`, `include_meta`) |
+| `GET /api/trace/:id` | Trace detail by trace id or session id (`limit`, `before`, `include_meta`, `payload`) |
+| `GET /api/trace/:id/event/:eventId` | Full trace event by trace id/session id and event id |
 | `GET /api/activity/day` | Daily activity bins + session/event aggregates |
 | `GET /api/activity/week` | Multi-day heatmap activity bins |
 | `POST /api/trace/:id/stop` | Stop session process (`force=true` optional) |
 | `POST /api/trace/:id/open` | Focus/open terminal target for trace |
 | `POST /api/trace/:id/input` | Send text input to session process |
 | `GET /api/tracefile?path=<base64url>` | Ad-hoc trace detail from absolute file path token |
+| `GET /api/tracefile/event?path=<base64url>&event_id=<id>` | Full ad-hoc trace event from absolute file path token |
 | `GET /api/config` | Current merged runtime config |
 | `POST /api/config` | Merge + persist config and refresh index |
 | `GET /api/stream` | SSE stream (`snapshot`, `trace_*`, `events_appended`, `overview_updated`, `heartbeat`) |
@@ -27,6 +29,11 @@ Base URL (default): `http://127.0.0.1:8787`
 
 - `limit` (int, max 5000)
 - `before` (cursor)
+- `include_meta` (`0|1|true|false`)
+- `payload` (`full|compact`, default `full`; `compact` omits full raw provider JSON from list events)
+
+### `GET /api/trace/:id/event/:eventId`
+
 - `include_meta` (`0|1|true|false`)
 
 ### `GET /api/traces`
@@ -55,11 +62,18 @@ Daily window is a 24-hour cycle anchored at `7:00` local time (`date 07:00` to n
 ### `GET /api/tracefile`
 
 - `path` required, base64url-encoded absolute path
-- optional: `limit`, `before`, `include_meta`
+- optional: `limit`, `before`, `include_meta`, `payload`
+
+### `GET /api/tracefile/event`
+
+- `path` required, base64url-encoded absolute path
+- `event_id` required
+- optional: `include_meta`
 
 ## Response Notes
 
-- successful trace endpoints return `TracePage` shape: `summary`, `events`, `toc`, `nextBefore`, `liveCursor`
+- successful trace page endpoints return `TracePage` shape: `summary`, `events`, `toc`, `nextBefore`, `liveCursor`, `eventPayload`
+- successful trace event endpoints return `{ event }`
 - successful activity endpoints return `AgentActivityDay` / `AgentActivityWeek`
 - unknown trace/session id: `404`
 - invalid ad-hoc token/path: `400`

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -232,12 +232,15 @@ export interface TraceTocItem {
   toolType: string;
 }
 
+export type TraceEventPayloadMode = "full" | "compact";
+
 export interface TracePage {
   summary: TraceSummary;
   events: NormalizedEvent[];
   toc: TraceTocItem[];
   nextBefore: string;
   liveCursor: string;
+  eventPayload?: TraceEventPayloadMode;
 }
 
 export type IndexStartupPhase = "cold" | "bootstrapping" | "hydrating" | "ready" | "failed";

--- a/packages/core/src/__tests__/activityStatus.test.ts
+++ b/packages/core/src/__tests__/activityStatus.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, mkdir, utimes, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import type { TraceSummary } from "@agentlens/contracts";
 import { describe, expect, it } from "vitest";
 import { mergeConfig } from "../config.js";
 import { TraceIndex } from "../traceIndex.js";
@@ -18,7 +19,7 @@ interface StatusFixtureOptions {
 async function loadSummaryForCodexLines(
   lines: string[],
   options: StatusFixtureOptions = {},
-): Promise<import("@agentlens/contracts").TraceSummary> {
+): Promise<TraceSummary> {
   const root = await createTempRoot();
   const codexDir = path.join(root, ".codex", "sessions", "2026", "02", "12");
   await mkdir(codexDir, { recursive: true });
@@ -328,7 +329,7 @@ describe("trace activity status", () => {
     expect(summary.activityReason).toBe("no_active_signal");
   });
 
-  it("marks waiting_input in cooldown band between running and idle", async () => {
+  it("marks non-terminal recent activity idle after the running window expires", async () => {
     const summary = await loadSummaryForCodexLines(
       [
         JSON.stringify({
@@ -353,8 +354,8 @@ describe("trace activity status", () => {
       },
     );
 
-    expect(summary.activityStatus).toBe("waiting_input");
-    expect(summary.activityReason).toBe("recent_activity_cooling");
+    expect(summary.activityStatus).toBe("idle");
+    expect(summary.activityReason).toBe("no_active_signal");
   });
 
   it("recomputes stale status on refresh even without file changes", async () => {

--- a/packages/core/src/__tests__/activityStatusTerminal.test.ts
+++ b/packages/core/src/__tests__/activityStatusTerminal.test.ts
@@ -1,0 +1,387 @@
+import { mkdtemp, mkdir, utimes, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { AgentKind, SourceProfileConfig, TraceSummary } from "@agentlens/contracts";
+import { describe, expect, it } from "vitest";
+import { mergeConfig } from "../config.js";
+import { TraceIndex } from "../traceIndex.js";
+
+interface AgentLogFixtureOptions {
+  agent: AgentKind;
+  relativePath: string;
+  sourceName?: string;
+  includeGlobs?: string[];
+  fileContents: string;
+  extraFiles?: Array<{ relativePath: string; contents: string }>;
+  mtimeMs?: number;
+}
+
+async function createTempRoot(): Promise<string> {
+  return mkdtemp(path.join(os.tmpdir(), "agentlens-core-terminal-status-"));
+}
+
+async function loadSummaryForAgentLog(options: AgentLogFixtureOptions): Promise<TraceSummary> {
+  const root = await createTempRoot();
+  const tracePath = path.join(root, options.relativePath);
+  await mkdir(path.dirname(tracePath), { recursive: true });
+  await writeFile(tracePath, options.fileContents, "utf8");
+  for (const extraFile of options.extraFiles ?? []) {
+    const extraPath = path.join(root, extraFile.relativePath);
+    await mkdir(path.dirname(extraPath), { recursive: true });
+    await writeFile(extraPath, extraFile.contents, "utf8");
+  }
+  if (options.mtimeMs !== undefined) {
+    const mtime = new Date(options.mtimeMs);
+    await utimes(tracePath, mtime, mtime);
+  }
+
+  const sourceName = options.sourceName ?? `${options.agent}_fixture`;
+  const source: SourceProfileConfig = {
+    name: sourceName,
+    enabled: true,
+    roots: [path.dirname(tracePath)],
+    includeGlobs: options.includeGlobs ?? [path.basename(tracePath)],
+    excludeGlobs: [],
+    maxDepth: 8,
+    agentHint: options.agent,
+  };
+  const config = mergeConfig({
+    scan: {
+      mode: "adaptive",
+      intervalSeconds: 2,
+      intervalMinMs: 200,
+      intervalMaxMs: 3000,
+      fullRescanIntervalMs: 900_000,
+      batchDebounceMs: 120,
+      recentEventWindow: 400,
+      includeMetaDefault: true,
+      statusRunningTtlMs: 300_000,
+      statusWaitingTtlMs: 900_000,
+    },
+    sessionLogDirectories: [],
+    sources: {
+      [sourceName]: source,
+    },
+  });
+
+  const index = new TraceIndex(config);
+  await index.refresh();
+  const summary = index.getSummaries()[0];
+  if (!summary) {
+    throw new Error("missing trace summary");
+  }
+  return summary;
+}
+
+describe("terminal trace activity status", () => {
+  it("marks Codex task_complete sessions idle immediately", async () => {
+    const summary = await loadSummaryForAgentLog({
+      agent: "codex",
+      relativePath: ".codex/sessions/2026/02/12/status.jsonl",
+      fileContents: [
+        JSON.stringify({
+          timestamp: "2026-02-12T10:00:00.000Z",
+          type: "session_meta",
+          payload: { id: "codex-complete-status" },
+        }),
+        JSON.stringify({
+          timestamp: "2026-02-12T10:00:01.000Z",
+          type: "event_msg",
+          payload: { type: "task_started" },
+        }),
+        JSON.stringify({
+          timestamp: "2026-02-12T10:00:02.000Z",
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "All checks passed." }],
+          },
+        }),
+        JSON.stringify({
+          timestamp: "2026-02-12T10:00:03.000Z",
+          type: "event_msg",
+          payload: { type: "task_complete" },
+        }),
+        JSON.stringify({
+          timestamp: "2026-02-12T10:00:04.000Z",
+          type: "event_msg",
+          payload: { type: "token_count" },
+        }),
+      ].join("\n"),
+    });
+
+    expect(summary.activityStatus).toBe("idle");
+    expect(summary.activityReason).toBe("terminal_done");
+  });
+
+  it("marks Claude end_turn sessions idle despite trailing housekeeping rows", async () => {
+    const summary = await loadSummaryForAgentLog({
+      agent: "claude",
+      relativePath: ".claude/projects/status.jsonl",
+      fileContents: [
+        JSON.stringify({
+          timestamp: "2026-02-12T10:00:00.000Z",
+          type: "assistant",
+          sessionId: "claude-complete-status",
+          message: {
+            role: "assistant",
+            type: "message",
+            stop_reason: "end_turn",
+            content: [{ type: "text", text: "Done and verified." }],
+          },
+        }),
+        JSON.stringify({
+          timestamp: "2026-02-12T10:00:01.000Z",
+          type: "system",
+          sessionId: "claude-complete-status",
+        }),
+        JSON.stringify({
+          type: "last-prompt",
+          sessionId: "claude-complete-status",
+        }),
+      ].join("\n"),
+    });
+
+    expect(summary.activityStatus).toBe("idle");
+    expect(summary.activityReason).toBe("terminal_done");
+  });
+
+  it("marks Pi stop final-answer sessions idle", async () => {
+    const summary = await loadSummaryForAgentLog({
+      agent: "pi",
+      relativePath: ".pi/agent/sessions/status.jsonl",
+      fileContents: [
+        JSON.stringify({
+          type: "session",
+          id: "pi-complete-status",
+          timestamp: "2026-02-12T10:00:00.000Z",
+          cwd: "/tmp/pi",
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "user-1",
+          timestamp: "2026-02-12T10:00:01.000Z",
+          message: {
+            role: "user",
+            content: [{ type: "text", text: "Respond exactly" }],
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "assistant-1",
+          timestamp: "2026-02-12T10:00:02.000Z",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "text",
+                text: "DONE",
+                textSignature: "{\"v\":1,\"phase\":\"final_answer\"}",
+              },
+            ],
+            stopReason: "stop",
+          },
+        }),
+      ].join("\n"),
+    });
+
+    expect(summary.activityStatus).toBe("idle");
+    expect(summary.activityReason).toBe("terminal_done");
+  });
+
+  it("marks Gemini final text followed by $set idle", async () => {
+    const summary = await loadSummaryForAgentLog({
+      agent: "gemini",
+      relativePath: ".gemini/tmp/chats/session-status.jsonl",
+      fileContents: [
+        JSON.stringify({
+          sessionId: "gemini-complete-status",
+          startTime: "2026-02-12T10:00:00.000Z",
+          lastUpdated: "2026-02-12T10:00:00.000Z",
+          kind: "main",
+        }),
+        JSON.stringify({
+          id: "user-1",
+          timestamp: "2026-02-12T10:00:01.000Z",
+          type: "user",
+          content: [{ text: "Respond exactly" }],
+        }),
+        JSON.stringify({
+          id: "assistant-1",
+          timestamp: "2026-02-12T10:00:02.000Z",
+          type: "gemini",
+          content: "DONE",
+        }),
+        JSON.stringify({
+          $set: { lastUpdated: "2026-02-12T10:00:02.000Z" },
+        }),
+      ].join("\n"),
+    });
+
+    expect(summary.activityStatus).toBe("idle");
+    expect(summary.activityReason).toBe("terminal_done");
+  });
+
+  it("marks Cursor final assistant text idle without depending on the text value", async () => {
+    const summary = await loadSummaryForAgentLog({
+      agent: "cursor",
+      relativePath: ".cursor/projects/tmp/agent-transcripts/status/status.jsonl",
+      fileContents: [
+        JSON.stringify({
+          role: "user",
+          message: {
+            content: [{ type: "text", text: "Summarize the verification result." }],
+          },
+        }),
+        JSON.stringify({
+          role: "assistant",
+          message: {
+            content: [{ type: "text", text: "Verification completed successfully with no follow-up required." }],
+          },
+        }),
+      ].join("\n"),
+    });
+
+    expect(summary.activityStatus).toBe("idle");
+    expect(summary.activityReason).toBe("terminal_done");
+  });
+
+  it("marks OpenCode step-finish stop sessions idle", async () => {
+    const sessionId = "ses_status_complete";
+    const messageId = "msg_status_complete";
+    const summary = await loadSummaryForAgentLog({
+      agent: "opencode",
+      sourceName: "opencode_storage_session",
+      relativePath: `storage/session/project/${sessionId}.json`,
+      includeGlobs: ["**/*.json"],
+      fileContents: JSON.stringify({
+        id: sessionId,
+        projectID: "project",
+        directory: "/tmp/opencode",
+        title: "OpenCode status complete",
+        time: {
+          created: Date.parse("2026-02-12T10:00:00.000Z"),
+          updated: Date.parse("2026-02-12T10:00:03.000Z"),
+        },
+      }),
+      extraFiles: [
+        {
+          relativePath: `storage/message/${sessionId}/${messageId}.json`,
+          contents: JSON.stringify({
+            id: messageId,
+            sessionID: sessionId,
+            role: "assistant",
+            time: {
+              created: Date.parse("2026-02-12T10:00:01.000Z"),
+              completed: Date.parse("2026-02-12T10:00:03.000Z"),
+            },
+          }),
+        },
+        {
+          relativePath: `storage/part/${messageId}/part-text.json`,
+          contents: JSON.stringify({
+            id: "part-text",
+            sessionID: sessionId,
+            messageID: messageId,
+            type: "text",
+            text: "DONE",
+            time: {
+              start: Date.parse("2026-02-12T10:00:02.000Z"),
+              end: Date.parse("2026-02-12T10:00:02.500Z"),
+            },
+            metadata: { openai: { phase: "final_answer" } },
+          }),
+        },
+        {
+          relativePath: `storage/part/${messageId}/part-finish.json`,
+          contents: JSON.stringify({
+            id: "part-finish",
+            sessionID: sessionId,
+            messageID: messageId,
+            type: "step-finish",
+            reason: "stop",
+            time: {
+              start: Date.parse("2026-02-12T10:00:03.000Z"),
+              end: Date.parse("2026-02-12T10:00:03.000Z"),
+            },
+          }),
+        },
+      ],
+    });
+
+    expect(summary.activityStatus).toBe("idle");
+    expect(summary.activityReason).toBe("terminal_done");
+  });
+
+  it("keeps a final assistant question waiting for input", async () => {
+    const summary = await loadSummaryForAgentLog({
+      agent: "codex",
+      relativePath: ".codex/sessions/2026/02/12/status.jsonl",
+      fileContents: [
+        JSON.stringify({
+          timestamp: "2026-02-12T10:00:00.000Z",
+          type: "session_meta",
+          payload: { id: "codex-waiting-terminal-prompt" },
+        }),
+        JSON.stringify({
+          timestamp: "2026-02-12T10:00:01.000Z",
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "Should I run the full verification gate now?" }],
+          },
+        }),
+        JSON.stringify({
+          timestamp: "2026-02-12T10:00:02.000Z",
+          type: "event_msg",
+          payload: { type: "task_complete" },
+        }),
+      ].join("\n"),
+    });
+
+    expect(summary.activityStatus).toBe("waiting_input");
+    expect(summary.activityReason).toBe("explicit_wait_marker_fresh");
+  });
+
+  it("does not keep an older prompt waiting after a later final answer", async () => {
+    const summary = await loadSummaryForAgentLog({
+      agent: "codex",
+      relativePath: ".codex/sessions/2026/02/12/status.jsonl",
+      fileContents: [
+        JSON.stringify({
+          timestamp: "2026-02-12T10:00:00.000Z",
+          type: "session_meta",
+          payload: { id: "codex-resolved-terminal-prompt" },
+        }),
+        JSON.stringify({
+          timestamp: "2026-02-12T10:00:01.000Z",
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "Should I run the full verification gate now?" }],
+          },
+        }),
+        JSON.stringify({
+          timestamp: "2026-02-12T10:00:02.000Z",
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "Done. Verification passed." }],
+          },
+        }),
+        JSON.stringify({
+          timestamp: "2026-02-12T10:00:03.000Z",
+          type: "event_msg",
+          payload: { type: "task_complete" },
+        }),
+      ].join("\n"),
+    });
+
+    expect(summary.activityStatus).toBe("idle");
+    expect(summary.activityReason).toBe("terminal_done");
+  });
+});

--- a/packages/core/src/traceIndex.ts
+++ b/packages/core/src/traceIndex.ts
@@ -364,12 +364,99 @@ function isWaitResolutionEvent(event: NormalizedEvent): boolean {
   return event.eventKind === "user" || event.eventKind === "tool_use" || event.eventKind === "tool_result";
 }
 
+function isPassiveActivityEvent(event: NormalizedEvent): boolean {
+  const raw = asRecord(event.raw);
+  const payload = asRecord(raw.payload);
+  const part = asRecord(raw.part);
+  const rawType = normalizeMarkerText(event.rawType || raw.type);
+  const payloadType = normalizeMarkerText(payload.type);
+  const partType = normalizeMarkerText(part.type);
+
+  if (rawType === "token count" || payloadType === "token count") return true;
+  if (rawType === "last prompt" || rawType === "ai title" || rawType === "permission mode") return true;
+  if (rawType === "attachment" || rawType === "file history snapshot" || rawType === "queue operation") return true;
+  if (rawType === "model change" || rawType === "thinking level change") return true;
+  if (rawType === "info" || rawType === "session" || rawType === "session meta" || rawType === "session diff meta") return true;
+  if (partType === "snapshot" || partType === "patch" || partType === "file") return true;
+  if (Object.prototype.hasOwnProperty.call(raw, "$set")) return true;
+  if (event.eventKind === "system" && event.textBlocks.length === 0) return true;
+  if (event.eventKind === "meta" && !payloadType && !partType && event.textBlocks.length === 0) return true;
+  return false;
+}
+
 function findPendingWaitSignalEvent(events: NormalizedEvent[]): NormalizedEvent | undefined {
   for (let idx = events.length - 1; idx >= 0; idx -= 1) {
     const event = events[idx];
     if (!event) continue;
     if (isWaitResolutionEvent(event)) return undefined;
     if (hasStructuredWaitingSignal(event) || hasTextWaitingSignal(event)) return event;
+    if (isPassiveActivityEvent(event)) continue;
+    if (event.eventKind === "assistant" && event.textBlocks.length > 0) return undefined;
+  }
+  return undefined;
+}
+
+function parseJsonRecord(value: string): Record<string, unknown> {
+  try {
+    return asRecord(JSON.parse(value) as unknown);
+  } catch {
+    return {};
+  }
+}
+
+function hasFinalAnswerMarker(event: NormalizedEvent): boolean {
+  const raw = asRecord(event.raw);
+  const message = asRecord(raw.message);
+  const part = asRecord(raw.part);
+  const partMetadata = asRecord(part.metadata);
+  const partOpenaiMetadata = asRecord(partMetadata.openai);
+  if (normalizeMarkerText(partMetadata.phase) === "final answer") return true;
+  if (normalizeMarkerText(partOpenaiMetadata.phase) === "final answer") return true;
+
+  for (const item of Array.isArray(message.content) ? message.content : []) {
+    const itemRecord = asRecord(item);
+    if (normalizeMarkerText(itemRecord.phase) === "final answer") return true;
+    const signature = asString(itemRecord.textSignature);
+    if (signature && normalizeMarkerText(parseJsonRecord(signature).phase) === "final answer") return true;
+  }
+
+  return false;
+}
+
+function isTerminalDoneEvent(event: NormalizedEvent): boolean {
+  const raw = asRecord(event.raw);
+  const payload = asRecord(raw.payload);
+  const message = asRecord(raw.message);
+  const part = asRecord(raw.part);
+  const rawType = normalizeMarkerText(raw.type || event.rawType);
+  const payloadType = normalizeMarkerText(payload.type);
+  const messageStopReason = normalizeMarkerText(message.stop_reason || message.stopReason || raw.stop_reason || raw.stopReason);
+  const partType = normalizeMarkerText(part.type);
+  const partReason = normalizeMarkerText(part.reason);
+
+  if (payloadType === "task complete") return true;
+  if (rawType === "assistant" && messageStopReason === "end turn") return true;
+  if (event.eventKind === "assistant" && messageStopReason === "stop") return true;
+  if (partType === "step finish" && partReason === "stop") return true;
+  if (hasFinalAnswerMarker(event)) return true;
+  if (
+    event.eventKind === "assistant" &&
+    (rawType === "gemini" || rawType === "model" || rawType === "cursor jsonl assistant" || rawType === "cursor assistant") &&
+    event.textBlocks.length > 0
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function findLatestTerminalDoneEvent(events: NormalizedEvent[]): NormalizedEvent | undefined {
+  for (let idx = events.length - 1; idx >= 0; idx -= 1) {
+    const event = events[idx];
+    if (!event) continue;
+    if (isPassiveActivityEvent(event)) continue;
+    if (isTerminalDoneEvent(event)) return event;
+    return undefined;
   }
   return undefined;
 }
@@ -398,16 +485,6 @@ function applyFreshnessTtl(
 }
 
 function deriveActivityStatus(options: ActivityStatusOptions): ActivityStatus {
-  const pendingWaitSignalEvent = findPendingWaitSignalEvent(options.events);
-  if (pendingWaitSignalEvent) {
-    return applyFreshnessTtl(
-      { status: "waiting_input", reason: "explicit_wait_marker_fresh" },
-      options.updatedMs,
-      options.nowMs,
-      options.scanConfig,
-    );
-  }
-
   if (options.unmatchedToolUses > 0) {
     return applyFreshnessTtl(
       { status: "running", reason: "pending_tool_use_fresh" },
@@ -418,16 +495,25 @@ function deriveActivityStatus(options: ActivityStatusOptions): ActivityStatus {
     );
   }
 
+  const pendingWaitSignalEvent = findPendingWaitSignalEvent(options.events);
+  if (pendingWaitSignalEvent) {
+    return applyFreshnessTtl(
+      { status: "waiting_input", reason: "explicit_wait_marker_fresh" },
+      options.updatedMs,
+      options.nowMs,
+      options.scanConfig,
+    );
+  }
+
+  if (findLatestTerminalDoneEvent(options.events)) {
+    return { status: "idle", reason: "terminal_done" };
+  }
+
   if (options.updatedMs > 0) {
     const runningAgeMs = Math.max(0, options.nowMs - options.updatedMs);
     const runningTtlMs = Math.max(0, options.scanConfig.statusRunningTtlMs);
     if (runningAgeMs <= runningTtlMs) {
       return { status: "running", reason: "recent_activity_fresh" };
-    }
-
-    const waitingTtlMs = Math.max(0, options.scanConfig.statusWaitingTtlMs);
-    if (runningAgeMs > runningTtlMs && runningAgeMs <= waitingTtlMs) {
-      return { status: "waiting_input", reason: "recent_activity_cooling" };
     }
   }
 
@@ -494,9 +580,8 @@ function withAgedActivityStatus(summary: TraceSummary, fileMtimeMs: number, scan
     if (summary.activityStatus === "running" && summary.activityReason === "pending_tool_use_fresh") return summary;
     return { ...summary, activityStatus: "running", activityReason: "pending_tool_use_fresh" };
   }
-  if (summary.activityStatus === "running" && ageMs > runningTtlMs && ageMs <= waitingTtlMs) {
-    if (summary.activityReason === "recent_activity_cooling") return summary;
-    return { ...summary, activityStatus: "waiting_input", activityReason: "recent_activity_cooling" };
+  if (summary.activityStatus === "running" && ageMs > runningTtlMs) {
+    return { ...summary, activityStatus: "idle", activityReason: "stale_timeout" };
   }
   return summary;
 }

--- a/packages/core/src/traceIndex.ts
+++ b/packages/core/src/traceIndex.ts
@@ -18,6 +18,7 @@ import type {
   SessionActivityStatus,
   SessionDetail,
   StreamEnvelope,
+  TraceEventPayloadMode,
   TracePage,
   TraceTocItem,
   TraceSummary,
@@ -71,6 +72,7 @@ export interface TracePageOptions {
   limit?: number;
   before?: string;
   includeMeta?: boolean;
+  eventPayload?: TraceEventPayloadMode;
 }
 
 export interface TraceIndexEvent {
@@ -716,6 +718,53 @@ function buildToc(events: NormalizedEvent[]): TraceTocItem[] {
     colorKey: event.eventKind,
     toolType: event.toolType,
   }));
+}
+
+function compactTextField(value: string, maxLength = 240): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength)}...`;
+}
+
+function copyStringField(source: Record<string, unknown>, key: string, target: Record<string, unknown>): void {
+  const value = source[key];
+  if (typeof value === "string" && value) {
+    target[key] = value;
+  }
+}
+
+function buildCompactRaw(raw: Record<string, unknown>): Record<string, unknown> {
+  const compact: Record<string, unknown> = {};
+  copyStringField(raw, "type", compact);
+  copyStringField(raw, "subtype", compact);
+  copyStringField(raw, "model", compact);
+
+  const payload = asRecord(raw.payload);
+  const compactPayload: Record<string, unknown> = {};
+  copyStringField(payload, "model", compactPayload);
+  copyStringField(payload, "approval_policy", compactPayload);
+  if (Object.keys(compactPayload).length > 0) {
+    compact.payload = compactPayload;
+  }
+
+  const data = asRecord(raw.data);
+  const compactData: Record<string, unknown> = {};
+  copyStringField(data, "hookEvent", compactData);
+  if (Object.keys(compactData).length > 0) {
+    compact.data = compactData;
+  }
+
+  return compact;
+}
+
+function compactEventForList(event: NormalizedEvent): NormalizedEvent {
+  return {
+    ...event,
+    textBlocks: [],
+    toolArgsText: compactTextField(event.toolArgsText),
+    toolResultText: compactTextField(event.toolResultText),
+    searchText: "",
+    raw: buildCompactRaw(event.raw),
+  };
 }
 
 function byteLengthUtf8(value: string): number {
@@ -1950,19 +1999,32 @@ export class TraceIndex extends EventEmitter {
     const detail = this.getSessionDetail(id);
     const includeMeta = options.includeMeta ?? this.config.scan.includeMetaDefault;
     const filtered = includeMeta ? detail.events : detail.events.filter((event) => event.eventKind !== "meta");
+    const eventPayload = options.eventPayload ?? "full";
 
     const limit = Math.max(1, Math.min(5000, options.limit ?? this.config.scan.recentEventWindow));
     const end = options.before ? Math.max(0, Math.min(filtered.length, Number(options.before))) : filtered.length;
     const start = Math.max(0, end - limit);
     const pageEvents = filtered.slice(start, end);
+    const events = eventPayload === "compact" ? pageEvents.map(compactEventForList) : pageEvents;
 
     return {
       summary: detail.summary,
-      events: pageEvents,
+      events,
       toc: buildToc(pageEvents),
       nextBefore: start > 0 ? String(start) : "",
       liveCursor: String(filtered.length),
+      eventPayload,
     };
+  }
+
+  getTraceEvent(id: string, eventId: string, options: Pick<TracePageOptions, "includeMeta"> = {}): NormalizedEvent {
+    const detail = this.getSessionDetail(id);
+    const includeMeta = options.includeMeta ?? this.config.scan.includeMetaDefault;
+    const found = detail.events.find((event) => event.eventId === eventId);
+    if (!found || (!includeMeta && found.eventKind === "meta")) {
+      throw new Error(`unknown trace event: ${eventId}`);
+    }
+    return found;
   }
 
   resolveId(candidate: string): string {


### PR DESCRIPTION
## Summary
- pace live session and trace event rendering through animation-frame chunks so large bursts do not paint all at once
- fetch compact Trace Inspector event payloads for collapsed cards and lazy-load full raw JSON only when an event is expanded
- update trace activity status coverage and TBD changelog notes for the next release

## Why
Chrome was warning that the AgentLens tab was slowing the browser. The selected trace detail path was sending full raw provider JSON for every visible event, creating multi-megabyte responses and unnecessary browser parse/memory pressure.

## Verification
- npm -w apps/web test
- npm -w apps/server test
- npm run typecheck
- npm test
- npm run build
- Playwright smoke check against http://127.0.0.1:8787: page renders, compact trace requests are used, event expand fetches /event/..., browser console has no errors
- Live payload check: full trace detail around 10.5 MB, compact trace detail around 0.7 MB on a large local trace
